### PR TITLE
Updated critical changes in the ADB urls

### DIFF
--- a/cloud-foundation/solutions/Deploy-ChatDB-Autonomous-Database-Select-AI-demonstration/modules/cloud-foundation-library/database/adb/outputs.tf
+++ b/cloud-foundation/solutions/Deploy-ChatDB-Autonomous-Database-Select-AI-demonstration/modules/cloud-foundation-library/database/adb/outputs.tf
@@ -44,7 +44,7 @@ value = oci_database_autonomous_database_wallet.autonomous_database_wallet["adw"
 }
 
 output "database_fully_qualified_name" {
-  value = lower(trimsuffix(trimprefix(join("\n", [for b in oci_database_autonomous_database.adw : b.connection_urls.0.graph_studio_url]), "https://"), "/graphstudio/"))
+  value = lower(trimsuffix(trimprefix(join("\n", [for b in oci_database_autonomous_database.adw : b.connection_urls.0.graph_studio_url]), "https://"), "/graphstudio/?sso=true"))
 }
 
 output "adw" {
@@ -59,6 +59,6 @@ output "apex_url" {
 }
 
 output "select_ai_demo_url" {
-  value = join("", [lower(trimsuffix(join("\n", [for b in oci_database_autonomous_database.adw : b.connection_urls.0.graph_studio_url]), "/graphstudio/")),"/ords/r/moviestream/chatdb"])
+  value = join("", [lower(trimsuffix(join("\n", [for b in oci_database_autonomous_database.adw : b.connection_urls.0.graph_studio_url]), "/graphstudio/?sso=true")),"/ords/r/moviestream/chatdb"])
 }
 

--- a/cloud-foundation/solutions/Deploy-ChatDB-Autonomous-Database-oci-genai-demonstration/modules/cloud-foundation-library/database/adb/outputs.tf
+++ b/cloud-foundation/solutions/Deploy-ChatDB-Autonomous-Database-oci-genai-demonstration/modules/cloud-foundation-library/database/adb/outputs.tf
@@ -44,7 +44,7 @@ value = oci_database_autonomous_database_wallet.autonomous_database_wallet["adw"
 }
 
 output "database_fully_qualified_name" {
-  value = lower(trimsuffix(trimprefix(join("\n", [for b in oci_database_autonomous_database.adw : b.connection_urls.0.graph_studio_url]), "https://"), "/graphstudio/"))
+  value = lower(trimsuffix(trimprefix(join("\n", [for b in oci_database_autonomous_database.adw : b.connection_urls.0.graph_studio_url]), "https://"), "/graphstudio/?sso=true"))
 }
 
 output "adw" {
@@ -59,6 +59,6 @@ output "apex_url" {
 }
 
 output "select_ai_demo_url" {
-  value = join("", [lower(trimsuffix(join("\n", [for b in oci_database_autonomous_database.adw : b.connection_urls.0.graph_studio_url]), "/graphstudio/")),"/ords/r/moviestream/chatdb"])
+  value = join("", [lower(trimsuffix(join("\n", [for b in oci_database_autonomous_database.adw : b.connection_urls.0.graph_studio_url]), "/graphstudio/?sso=true")),"/ords/r/moviestream/chatdb"])
 }
 

--- a/cloud-foundation/solutions/RAG-in-a-Box-Easy/modules/cloud-foundation-library/database/adb/outputs.tf
+++ b/cloud-foundation/solutions/RAG-in-a-Box-Easy/modules/cloud-foundation-library/database/adb/outputs.tf
@@ -44,7 +44,7 @@ value = oci_database_autonomous_database_wallet.autonomous_database_wallet["adw"
 }
 
 output "database_fully_qualified_name" {
-  value = lower(trimsuffix(trimprefix(join("\n", [for b in oci_database_autonomous_database.adw : b.connection_urls.0.graph_studio_url]), "https://"), "/graphstudio/"))
+  value = lower(trimsuffix(trimprefix(join("\n", [for b in oci_database_autonomous_database.adw : b.connection_urls.0.graph_studio_url]), "https://"), "/graphstudio/?sso=true"))
 }
 
 output "adw" {
@@ -59,6 +59,6 @@ output "apex_url" {
 }
 
 output "easyRAG_IN_A_BOX_URL" {
-  value = join("", [lower(trimsuffix(join("\n", [for b in oci_database_autonomous_database.adw : b.connection_urls.0.graph_studio_url]), "/graphstudio/")),"/ords/r/riab/erag-in-a-box102"])
+  value = join("", [lower(trimsuffix(join("\n", [for b in oci_database_autonomous_database.adw : b.connection_urls.0.graph_studio_url]), "/graphstudio/?sso=true")),"/ords/r/riab/erag-in-a-box102"])
 }
 

--- a/cloud-foundation/solutions/RAG-in-a-Box-Hybrid/modules/cloud-foundation-library/database/adb/outputs.tf
+++ b/cloud-foundation/solutions/RAG-in-a-Box-Hybrid/modules/cloud-foundation-library/database/adb/outputs.tf
@@ -44,7 +44,7 @@ value = oci_database_autonomous_database_wallet.autonomous_database_wallet["adw"
 }
 
 output "database_fully_qualified_name" {
-  value = lower(trimsuffix(trimprefix(join("\n", [for b in oci_database_autonomous_database.adw : b.connection_urls.0.graph_studio_url]), "https://"), "/graphstudio/"))
+  value = lower(trimsuffix(trimprefix(join("\n", [for b in oci_database_autonomous_database.adw : b.connection_urls.0.graph_studio_url]), "https://"), "/graphstudio/?sso=true"))
 }
 
 output "adw" {
@@ -59,6 +59,6 @@ output "apex_url" {
 }
 
 output "hRAG_IN_A_BOX_URL" {
-  value = join("", [lower(trimsuffix(join("\n", [for b in oci_database_autonomous_database.adw : b.connection_urls.0.graph_studio_url]), "/graphstudio/")),"/ords/r/hriab/hrag-in-a-box102"])
+  value = join("", [lower(trimsuffix(join("\n", [for b in oci_database_autonomous_database.adw : b.connection_urls.0.graph_studio_url]), "/graphstudio/?sso=true")),"/ords/r/hriab/hrag-in-a-box102"])
 }
 

--- a/cloud-foundation/solutions/RAG-in-a-Box-Vector/modules/cloud-foundation-library/database/adb/outputs.tf
+++ b/cloud-foundation/solutions/RAG-in-a-Box-Vector/modules/cloud-foundation-library/database/adb/outputs.tf
@@ -44,7 +44,7 @@ value = oci_database_autonomous_database_wallet.autonomous_database_wallet["adw"
 }
 
 output "database_fully_qualified_name" {
-  value = lower(trimsuffix(trimprefix(join("\n", [for b in oci_database_autonomous_database.adw : b.connection_urls.0.graph_studio_url]), "https://"), "/graphstudio/"))
+  value = lower(trimsuffix(trimprefix(join("\n", [for b in oci_database_autonomous_database.adw : b.connection_urls.0.graph_studio_url]), "https://"), "/graphstudio/?sso=true"))
 }
 
 output "adw" {
@@ -59,6 +59,6 @@ output "apex_url" {
 }
 
 output "vRAG_IN_A_BOX_URL" {
-  value = join("", [lower(trimsuffix(join("\n", [for b in oci_database_autonomous_database.adw : b.connection_urls.0.graph_studio_url]), "/graphstudio/")),"/ords/r/riab/vrag-in-a-box102"])
+  value = join("", [lower(trimsuffix(join("\n", [for b in oci_database_autonomous_database.adw : b.connection_urls.0.graph_studio_url]), "/graphstudio/?sso=true")),"/ords/r/riab/vrag-in-a-box102"])
 }
 


### PR DESCRIPTION
ADB has changed the URLs for graphstudio, and that URL was being used to create the database_fully_qualified_name and also the select_ai_demo_url in 5 of the terraform scripts, which needed to be changed with the addition of "?sso=true" in the output.tf files under the modules.

Affected TF scripts were:
- cloud-foundation/solutions/Deploy-ChatDB-Autonomous-Database-Select-AI-demonstration
- cloud-foundation/solutions/Deploy-ChatDB-Autonomous-Database-oci-genai-demonstration
- cloud-foundation/solutions/RAG-in-a-Box-Easy
- cloud-foundation/solutions/RAG-in-a-Box-Hybrid
- cloud-foundation/solutions/RAG-in-a-Box-Vector